### PR TITLE
fix for loading NFL player

### DIFF
--- a/lib/sportradar/api/nfl/season.rb
+++ b/lib/sportradar/api/nfl/season.rb
@@ -9,7 +9,7 @@ module Sportradar
         @year = data["year"]
         @type = data["type"]
         @name = data["name"]
-        @team = Sportradar::Api::Nfl::Team.new data["team"] if data["team"]
+        @team = Sportradar::Api::Nfl::Team.new(data["team"]) if data["team"].is_a?(Hash)
         @injuries = data["injuries"]["team"].map {|team| Sportradar::Api::Nfl::Team.new team } if data["injuries"] && data["injuries"]["team"]
         set_weeks
       end


### PR DESCRIPTION
This fixes an issue with loading a player. What would happen is that `data["team"]` was an array of (2) teams, which had been passed from a `Game`. I haven't found anything this change breaks (yet).
