### PR TITLE
improves NFL::Season, NFL::Team, NFL::Game

### DIFF
--- a/lib/sportradar/api/nfl/game.rb
+++ b/lib/sportradar/api/nfl/game.rb
@@ -26,9 +26,10 @@ module Sportradar
         @scoring = Sportradar::Api::Nfl::Scoring.new data["scoring"] if data["scoring"]
         set_scoring_drives
 
-        @venue = Sportradar::Api::Nfl::Venue.new data["venue"] if data["venue"]
-        @home = Sportradar::Api::Nfl::Team.new data["home"] if data["home"]
-        @away = Sportradar::Api::Nfl::Team.new data["away"] if data["away"]
+        location = data["summary"] || data
+        @venue = Sportradar::Api::Nfl::Venue.new location["venue"] if location["venue"]
+        @home = Sportradar::Api::Nfl::Team.new   location["home"]  if location["home"]
+        @away = Sportradar::Api::Nfl::Team.new   location["away"]  if location["away"]
         @broadcast = Sportradar::Api::Nfl::Broadcast.new data["broadcast"] if data["broadcast"]
       end
 

--- a/lib/sportradar/api/nfl/season.rb
+++ b/lib/sportradar/api/nfl/season.rb
@@ -1,7 +1,7 @@
 module Sportradar
   module Api
     class Nfl::Season < Data
-      attr_accessor :response, :id, :year, :type, :name, :weeks, :injuries, :team, :conferences
+      attr_accessor :response, :id, :year, :type, :name, :weeks, :injuries, :team, :conferences, :divisions, :teams
 
       def initialize(data)
         @response = data
@@ -13,6 +13,8 @@ module Sportradar
         @injuries = data["injuries"]["team"].map {|team| Sportradar::Api::Nfl::Team.new team } if data["injuries"] && data["injuries"]["team"]
         set_weeks
         set_conferences
+        set_divisions
+        set_teams
       end
 
       private
@@ -27,6 +29,9 @@ module Sportradar
         end
       end
 
+      # set_(conferences|divisions|teams) are all identical to the same methods in Hierarchy
+      # There is likely more overlap between Sportradar's NFL standings and NFL hierarchy APIs
+      # Eventually, these should be shared between classes
       def set_conferences
         if response["conference"]
           if response["conference"].is_a?(Array)
@@ -35,6 +40,22 @@ module Sportradar
             @conferences = [ Sportradar::Api::Nfl::Conference.new(response["conference"]) ]
           end
         end
+      end
+
+      def set_divisions
+        if conferences&.all? { |conference| conference.divisions }
+          @divisions = conferences.flat_map(&:divisions)
+        elsif response["division"]
+          if response["division"].is_a?(Array)
+            @divisions = response["division"].map {|division| Sportradar::Api::Nfl::Division.new division }
+          elsif response["division"].is_a?(Hash)
+            @divisions = [ Sportradar::Api::Nfl::Division.new(response["division"]) ]
+          end
+        end
+      end
+
+      def set_teams
+        @teams = @divisions.flat_map(&:teams) if divisions&.all? {|division| division.teams }
       end
 
     end

--- a/lib/sportradar/api/nfl/team.rb
+++ b/lib/sportradar/api/nfl/team.rb
@@ -24,7 +24,7 @@ module Sportradar
         @losses = data["losses"]
         @losses = data["losses"]
         @ties = data["ties"]
-        @win_pct = data["win_pct"].to_f
+        @win_pct = data["win_pct"].to_f if data["win_pct"]
         @rank = data["rank"]
 
         @defense = data["defense"]["position"].map {|position| Sportradar::Api::Nfl::Position.new position } if data["defense"] && data["defense"]["position"]

--- a/lib/sportradar/api/nfl/team.rb
+++ b/lib/sportradar/api/nfl/team.rb
@@ -43,8 +43,9 @@ module Sportradar
       end
 
       def record
-        return '' unless wins && losses && ties
-        "#{wins}-#{losses}" << (ties == '0' ? '' : "-#{ties}")
+        if wins && losses && ties
+          "#{wins}-#{losses}" << (ties == '0' ? '' : "-#{ties}")
+        end
       end
 
       private

--- a/lib/sportradar/api/nfl/team.rb
+++ b/lib/sportradar/api/nfl/team.rb
@@ -1,8 +1,7 @@
 module Sportradar
   module Api
     class Nfl::Team < Data
-      attr_accessor :response, :id, :name, :alias, :game_number, :defense, :special_teams, :offense, :players, :statistics, :team_records, :player_records, :market, :franchise, :venue, :hierarchy, :coaches, :players, :used_timeouts, :remaining_timeouts, :points
-
+      attr_accessor :response, :id, :name, :alias, :game_number, :defense, :special_teams, :offense, :players, :statistics, :team_records, :player_records, :market, :franchise, :venue, :hierarchy, :coaches, :players, :used_timeouts, :remaining_timeouts, :points, :wins, :losses, :ties, :win_pct, :rank
 
       def initialize(data)
         @response = data
@@ -21,6 +20,13 @@ module Sportradar
         @venue = Sportradar::Api::Nfl::Venue.new data["venue"] if data["venue"]
         @hierarchy = Sportradar::Api::Nfl::Hierarchy.new data["hierarchy"] if data["hierarchy"]
 
+        @wins = data["wins"]
+        @losses = data["losses"]
+        @losses = data["losses"]
+        @ties = data["ties"]
+        @win_pct = data["win_pct"].to_f
+        @rank = data["rank"]
+
         @defense = data["defense"]["position"].map {|position| Sportradar::Api::Nfl::Position.new position } if data["defense"] && data["defense"]["position"]
         @offense = data["offense"]["position"].map {|position| Sportradar::Api::Nfl::Position.new position } if data["offense"] && data["offense"]["position"]
         @special_teams = data["special_teams"]["position"].map {|position| Sportradar::Api::Nfl::Position.new position } if data["special_teams"] && data["special_teams"]["position"]
@@ -34,6 +40,11 @@ module Sportradar
 
       def full_name
         [market, name].join(' ')
+      end
+
+      def record
+        return '' unless wins && losses && ties
+        "#{wins}-#{losses}" << (ties == '0' ? '' : "-#{ties}")
       end
 
       private


### PR DESCRIPTION
This adds #divisions and #teams functionality to NFL::Season.

Additionally, we add the following attributes on NFL::Team: `:wins, :losses, :ties, :win_pct, :rank`.

These attributes allow for sorting teams inside a division to generate standings.

Additional changes for NFL::Game were needed for when the game is retrieved directly via API, instead of being instantiated via response of another API call. The data structure is slightly different and handled appropriately.
