### PR TITLE
Fixing Roster

### DIFF
--- a/lib/sportradar/api/nfl/game.rb
+++ b/lib/sportradar/api/nfl/game.rb
@@ -1,7 +1,7 @@
 module Sportradar
   module Api
     class Nfl::Game < Data
-      attr_accessor :response, :id, :status, :reference, :number, :scheduled, :entry_mode, :venue, :home, :away, :broadcast, :number, :attendance, :utc_offset, :weather, :clock, :quarter, :summary, :situation, :last_event, :scoring, :scoring_drives, :quarters, :stats, :home_roster, :away_roster
+      attr_accessor :response, :id, :status, :reference, :number, :scheduled, :entry_mode, :venue, :home, :away, :broadcast, :number, :attendance, :utc_offset, :weather, :clock, :quarter, :summary, :situation, :last_event, :scoring, :scoring_drives, :quarters, :stats
 
       def initialize(data)
         @response = data


### PR DESCRIPTION
I found out that the roster is getting it's information in a different way when calling `game_roster` as opposed to `game_statistics` on `lib/sportradar/api/nfl.rb`

Also refactored the players to be the returning method as well as return an array as the default in case there are no players returned.  Returning nil was causing an issue and since the method name is plural I figured returning an array would be implicit.
