### PR TITLE
Add team to player attr reader

### DIFF
--- a/lib/sportradar/api/soccer/player.rb
+++ b/lib/sportradar/api/soccer/player.rb
@@ -3,7 +3,7 @@ module Sportradar
     module Soccer
       class Player < Data
 
-        attr_reader :id, :league_group, :name, :type, :nationality, :country_code, :height, :weight, :jersey_number, :preferred_foot, :stats, :date_of_birth, :matches_played
+        attr_reader :id, :league_group, :name, :type, :nationality, :country_code, :height, :weight, :jersey_number, :preferred_foot, :stats, :date_of_birth, :matches_played, :team
         alias :position :type
 
         def initialize(data = {}, league_group: nil, **opts)

--- a/lib/sportradar/api/version.rb
+++ b/lib/sportradar/api/version.rb
@@ -1,5 +1,5 @@
 module Sportradar
   module Api
-    VERSION = "0.13.17"
+    VERSION = "0.13.18"
   end
 end


### PR DESCRIPTION
In order to access the player's team from `player_stats` expose `team`.

This will allow such actions for questions

```
sr.player_stats["sr:player:41614"][:player].team.id
```